### PR TITLE
Add feature: Edit the simpletoken.sol contract to add a pause functionality by onlyOwner which will not let users do anything with their tokens like mint, trasnfer etc..  

### DIFF
--- a/contracts/SimpleToken.sol
+++ b/contracts/SimpleToken.sol
@@ -8,7 +8,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  * @title SimpleToken
  * @dev A simple ERC20 token with mint and burn capabilities
  */
-contract SimpleToken is ERC20, Ownable {
+contract SimpleToken is ERC20, Ownable, Pausable {
     /**
      * @dev Constructor that initializes the token with name and symbol
      */
@@ -19,7 +19,7 @@ contract SimpleToken is ERC20, Ownable {
      * @param to The address that will receive the minted tokens
      * @param amount The amount of tokens to mint
      */
-    function mint(address to, uint256 amount) public onlyOwner {
+    function mint(address to, uint256 amount) public onlyOwner whenNotPaused {
         _mint(to, amount);
     }
 
@@ -39,4 +39,20 @@ contract SimpleToken is ERC20, Ownable {
     function burn(uint256 amount) public {
         _burn(msg.sender, amount);
     }
+
+    /**
+         * @dev Pause token transfers and operations
+         * Only callable by owner
+         */
+        function pause() public onlyOwner {
+            _pause();
+        }
+    
+        /**
+         * @dev Unpause token transfers and operations
+         * Only callable by owner
+         */
+        function unpause() public onlyOwner {
+            _unpause();
+        }
 }

--- a/test/SimpleToken.test.js
+++ b/test/SimpleToken.test.js
@@ -67,3 +67,36 @@ describe("SimpleToken", function () {
     });
   });
 });
+
+  describe('Pause functionality', function () {
+    it('should allow owner to pause and unpause', async function () {
+      await simpleToken.pause();
+      expect(await simpleToken.paused()).to.equal(true);
+      
+      await simpleToken.unpause();
+      expect(await simpleToken.paused()).to.equal(false);
+    });
+    
+    it('should prevent non-owners from pausing', async function () {
+      await expect(simpleToken.connect(addr1).pause()).to.be.reverted;
+    });
+    
+    it('should prevent transfers when paused', async function () {
+      await simpleToken.mint(owner.address, 100);
+      await simpleToken.pause();
+      
+      await expect(simpleToken.transfer(addr1.address, 10)).to.be.reverted;
+      await simpleToken.unpause();
+      await simpleToken.transfer(addr1.address, 10);
+      expect(await simpleToken.balanceOf(addr1.address)).to.equal(10);
+    });
+    
+    it('should prevent minting when paused', async function () {
+      await simpleToken.pause();
+      await expect(simpleToken.mint(addr1.address, 1000)).to.be.reverted;
+      
+      await simpleToken.unpause();
+      await simpleToken.mint(addr1.address, 1000);
+      expect(await simpleToken.balanceOf(addr1.address)).to.equal(1000);
+    });
+  });


### PR DESCRIPTION
This PR implements the following feature:

Edit the simpletoken.sol contract to add a pause functionality by onlyOwner which will not let users do anything with their tokens like mint, trasnfer etc..  

Automatically generated by AI Code Agent.