### PR TITLE
Add feature: Edit the simpletoken.sol contract to add a pause functionality by onlyOwner which will not let users do anything with their tokens like mint, trasnfer etc..  

### DIFF
--- a/contracts/SimpleToken.sol
+++ b/contracts/SimpleToken.sol
@@ -39,4 +39,51 @@ contract SimpleToken is ERC20, Ownable {
     function burn(uint256 amount) public {
         _burn(msg.sender, amount);
     }
+
+    /**
+         * @dev Pauses all token transfers.
+         * Requirements:
+         * - the caller must be the owner.
+         */
+        function pause() public onlyOwner {
+            _pause();
+        }
+    
+        /**
+         * @dev Unpauses all token transfers.
+         * Requirements:
+         * - the caller must be the owner.
+         */
+        function unpause() public onlyOwner {
+            _unpause();
+        }
 }
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/security/Pausable.sol";
+
+contract SimpleToken is ERC20, Ownable, Pausable {
+
+    function mint(address to, uint256 amount) public onlyOwner whenNotPaused {
+        _mint(to, amount);
+    }
+
+    function _transfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal override whenNotPaused {
+        super._transfer(from, to, amount);
+    }
+
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal override whenNotPaused {
+        super._approve(owner, spender, amount);
+    }

--- a/test/SimpleToken.test.js
+++ b/test/SimpleToken.test.js
@@ -15,6 +15,23 @@ describe("SimpleToken", function () {
 
   describe("Deployment", function () {
     it("Should set the right owner", async function () {
+  it("Should allow owner to pause and unpause", async function () {
+    await simpleToken.pause();
+    await expect(simpleToken.mint(addr1.address, 50)).to.be.reverted;
+    await expect(simpleToken.connect(addr1).transfer(addr2.address, 10)).to.be.reverted;
+    
+    await simpleToken.unpause();
+    await simpleToken.mint(addr1.address, 50);
+    await simpleToken.connect(addr1).transfer(addr2.address, 10);
+    expect(await simpleToken.balanceOf(addr2.address)).to.equal(10);
+  });
+
+  it("Should not allow non-owners to pause", async function () {
+    await expect(simpleToken.connect(addr1).pause()).to.be.reverted;
+    await expect(simpleToken.connect(addr1).unpause()).to.be.reverted;
+  });
+
+  
       expect(await simpleToken.owner()).to.equal(owner.address);
     });
 


### PR DESCRIPTION
This PR implements the following feature:

Edit the simpletoken.sol contract to add a pause functionality by onlyOwner which will not let users do anything with their tokens like mint, trasnfer etc..  

Automatically generated by AI Code Agent.